### PR TITLE
Update checkout to be a class

### DIFF
--- a/checkout.gemspec
+++ b/checkout.gemspec
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "lib/checkout/version"
-
 Gem::Specification.new do |spec|
   spec.name = "checkout"
-  spec.version = Checkout::VERSION
+  spec.version = 0
   spec.authors = ["Koru Kids"]
   spec.email = []
 

--- a/lib/checkout.rb
+++ b/lib/checkout.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
-require_relative "checkout/version"
-
-module Checkout
+class Checkout
 end

--- a/lib/checkout/version.rb
+++ b/lib/checkout/version.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module Checkout
-  VERSION = "0.1.0"
-end

--- a/spec/checkout_spec.rb
+++ b/spec/checkout_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Checkout do
-  it "has a version number" do
-    expect(Checkout::VERSION).not_to be nil
+  it "exists" do
+    expect(Checkout).to be
   end
 
   it "does something useful" do


### PR DESCRIPTION
Our spec explicitly initialises an instance the Checkout object, having the Checkout be a class makes more sense